### PR TITLE
Corrected the theme name in Tomorrow Night Eighties

### DIFF
--- a/color-scripts/base16-tomorrow-night-eighties-256.sh
+++ b/color-scripts/base16-tomorrow-night-eighties-256.sh
@@ -2,7 +2,7 @@
 # Base16 Tomorrow Night - Gnome Terminal color scheme install script
 # Chris Kempson (http://chriskempson.com)
 
-[[ -z "$PROFILE_NAME" ]] && PROFILE_NAME="Base 16 Tomorrow Night 256"
+[[ -z "$PROFILE_NAME" ]] && PROFILE_NAME="Base 16 Tomorrow Night Eighties 256"
 [[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG="base-16-tomorrow-night-eighties-256"
 [[ -z "$DCONF" ]] && DCONF=dconf
 [[ -z "$UUIDGEN" ]] && UUIDGEN=uuidgen

--- a/color-scripts/base16-tomorrow-night-eighties.sh
+++ b/color-scripts/base16-tomorrow-night-eighties.sh
@@ -2,7 +2,7 @@
 # Base16 Tomorrow Night - Gnome Terminal color scheme install script
 # Chris Kempson (http://chriskempson.com)
 
-[[ -z "$PROFILE_NAME" ]] && PROFILE_NAME="Base 16 Tomorrow Night"
+[[ -z "$PROFILE_NAME" ]] && PROFILE_NAME="Base 16 Tomorrow Night Eighties"
 [[ -z "$PROFILE_SLUG" ]] && PROFILE_SLUG="base-16-tomorrow-night-eighties"
 [[ -z "$DCONF" ]] && DCONF=dconf
 [[ -z "$UUIDGEN" ]] && UUIDGEN=uuidgen


### PR DESCRIPTION
I noticed the Tomorrow Night Eighties theme was being installed without the "Eighties" portion to the name. I don't know what the proper contribution guidelines are, but I figured I'd correct it if I can.